### PR TITLE
Check if __file__ variable is None during dependency collection

### DIFF
--- a/libraries/ml-lab-py/lab_client/commons/dependency_utils.py
+++ b/libraries/ml-lab-py/lab_client/commons/dependency_utils.py
@@ -427,7 +427,7 @@ def iterate_sys_modules():
 def get_sources_from_modules(module_iterator, base_path):
     sources = set()
     for modname, mod in module_iterator:
-        if not hasattr(mod, '__file__'):
+        if not hasattr(mod, '__file__') or mod.__file__ is None:
             continue
 
         filename = os.path.abspath(mod.__file__)
@@ -441,8 +441,9 @@ def get_sources_from_modules(module_iterator, base_path):
 def get_dependencies_from_modules(module_iterator, base_path):
     dependencies = set()
     for modname, mod in module_iterator:
-        if hasattr(mod, '__file__') and is_local_source(
-                os.path.abspath(mod.__file__), modname, base_path):
+        if (hasattr(mod, '__file__')
+                and mod.__file__ is not None
+                and is_local_source(os.path.abspath(mod.__file__), modname, base_path)):
             continue
         if modname.startswith('_') or '.' in modname:
             continue


### PR DESCRIPTION
<!--
Thank you for creating a pull request 🙌 ❤️
-->

**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] New Feature
- [ ] Feature Improvment
- [ ] Refactoring
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include a note to let us know. -->
This bugfix addresses issue https://github.com/SAP/machine-learning-lab/issues/6. More details can be found in my comments here: https://github.com/SAP/machine-learning-lab/issues/6#issuecomment-712092774
This fix checks if the \_\_fille\_\_ variable of a module is None and prevents it from being used if it is. This removes the error when creating an experiment. But also this will skip adding the local code to the experiment if it was imported from a folder without a \_\_init\_\_.py. I don't know if there is another way to get the location of the source files if the \_\_file\_\_ variable is set to None.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/sap/machine-learning-lab/blob/master/CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.