### PR TITLE
Add LAB_SSL_ROOT configuration variable

### DIFF
--- a/backend/lab-service/src/main/java/org/mltooling/lab/LabConfig.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/LabConfig.java
@@ -100,6 +100,11 @@ public class LabConfig {
   public static final boolean SERVICE_SSL_ENABLED =
       SystemUtils.getEnvVar(ENV_NAME_SSL_ENABLED, "false").equalsIgnoreCase("true");
 
+  // Folder on host where ssl certificate is stored
+  public static final String ENV_NAME_HOST_ROOT_SSL_MOUNT_PATH = "LAB_SSL_ROOT";
+  public static final String HOST_ROOT_SSL_MOUNT_PATH =
+      SystemUtils.getEnvVar(ENV_NAME_HOST_ROOT_SSL_MOUNT_PATH);
+
   // jwt secret for authentication layer
   // if env name is changed, also change it in Nginx!
   public static final String ENV_NAME_JWT_SECRET = "JWT_SECRET";
@@ -244,6 +249,10 @@ public class LabConfig {
     envVariables.put(LabConfig.ENV_NAME_PORTAINER_IMAGE, PORTAINER_IMAGE);
     envVariables.put(LabConfig.ENV_NAME_MODEL_SERVICE_IMAGE, MODEL_SERVICE_IMAGE);
     envVariables.put(LabConfig.ENV_NAME_BACKEND_SERVICE_IMAGE, BACKEND_SERVICE_IMAGE);
+
+    if (HOST_ROOT_SSL_MOUNT_PATH != null) {
+      envVariables.put(LabConfig.ENV_NAME_HOST_ROOT_SSL_MOUNT_PATH, HOST_ROOT_SSL_MOUNT_PATH);
+    }
 
     if (HOST_ROOT_DATA_MOUNT_PATH != null) {
       envVariables.put(LabConfig.ENV_NAME_HOST_ROOT_DATA_MOUNT_PATH, HOST_ROOT_DATA_MOUNT_PATH);

--- a/backend/lab-service/src/main/java/org/mltooling/lab/services/AbstractServiceManager.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/services/AbstractServiceManager.java
@@ -192,6 +192,18 @@ public abstract class AbstractServiceManager {
                   + sslEnabled);
         }
 
+        String hostRootSslMount =
+            backendService.getConfiguration().get(LabConfig.ENV_NAME_HOST_ROOT_SSL_MOUNT_PATH);
+        if ((StringUtils.isNullOrEmpty(hostRootSslMount)
+                && !StringUtils.isNullOrEmpty(LabConfig.HOST_ROOT_SSL_MOUNT_PATH))
+            || (!StringUtils.isNullOrEmpty(hostRootSslMount)
+                && !hostRootSslMount.equals(LabConfig.HOST_ROOT_SSL_MOUNT_PATH))) {
+          throw new Exception(
+              LabConfig.ENV_NAME_HOST_ROOT_SSL_MOUNT_PATH
+                  + " should be the same value as the one of the current Lab instance: "
+                  + hostRootSslMount);
+        }
+
         String hostRootMount =
             backendService.getConfiguration().get(LabConfig.ENV_NAME_HOST_ROOT_DATA_MOUNT_PATH);
         if ((StringUtils.isNullOrEmpty(hostRootMount)

--- a/docs/docs/installation/install-lab.md
+++ b/docs/docs/installation/install-lab.md
@@ -64,6 +64,11 @@ The container can be configured with following environment variables (`--env`):
         <td>false</td>
     </tr>
     <tr>
+        <td>LAB_SSL_ROOT</td>
+        <td>The path on the host system to the folder containing a custom ssl certificate. The folder must contain a cert.crt and cert.key file. This folder is mounted into the ML Lab container, so to renew the certificate it must be replaced on the host system and the ML Lab container has to be restarted. If the <i>LAB_SSL_ROOT</i> variable is not set, ML Lab will look for a volume named lab_ssl. If no such named volume exists, a self signed certificate will be generated. The <i>LAB_SSL_ROOT</i> variable is only valid for docker local mode as secretes are used on Kubernetes.
+        <td>(optional)</td>
+    </tr>
+    <tr>
         <td>LAB_NAMESPACE</td>
         <td>The namespace used for the ML Lab installation. At the moment, we suggest to not change this value.</td>
         <td>lab</td>
@@ -166,21 +171,21 @@ To start  ML Lab in a single-host (local) deployment execute:
 docker run --rm --env LAB_PORT=8091 -v /var/run/docker.sock:/var/run/docker.sock --env LAB_ACTION=install lab-service:latest
 ```
 
-After the installation is finished (after several minutes depending on intranet speed), visit `http://<HOSTIP>:8091` and login with `admin:admin`.
+After the installation is finished (after several minutes depending on internet speed), visit `http://<HOSTIP>:8091` and login with `admin:admin`.
 
 **Enable SSL**
 
-For SSL setup, create the certificates and mount them into the container's directory at `/resources/ssl` (`-v /workspace/ssl:/resources/ssl:ro`) and start with `--env SERVICE_SSL_ENABLED=true`:
-
+For SSL setup, create the certificate (files must be called cert.crt and cert.key) and specify their path on the host machine via the `LAB_SSL_ROOT` environment variable. Additionally you need to set `SERVICE_SSL_ENABLED` to true:
 ``` bash
 docker run --rm --env LAB_PORT=8091 \
     --env SERVICE_SSL_ENABLED=true \
+    --env LAB_SSL_ROOT=/workspace/ssl \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /workspace/ssl:/resources/ssl:ro \
     lab-service:latest
 ```
 
-If you don't provide certificates, a self-signed certificate is generated and used. Be aware that applications such as your browser might not trust the certificate.
+Alternatively, instead of specifying `LAB_SSL_ROOT`, the certificate can be provided in a docker volume named `lab_ssl`.
+If you don't provide a custom certificate, a self-signed certificate is generated and used. Be aware that applications such as your browser might not trust the certificate.
 
 ### Install with Kubernetes Mode (Own Cluster)
 
@@ -250,7 +255,7 @@ In the Managed Cluster scenario, the biggest difference is that you don't have t
 In this setup mode, ML Lab accesses the cluster via its ServiceAccount permissions and *not* via a mounted kube-config.
 
 !!! warn "Costs"
-    As volumes are created automatically on the infrastructure based on the Kubernetes persistent volume claims, make sure to have an eye on your costs and set the size for the volume via the respective environment variables accordingly. Even when deleting the Kuberentes PersistentVolume and PersistentVolumeClaim resources, the actual volumes might still exist on the cloud provider and have to be deleted manually. 
+    As volumes are created automatically on the infrastructure based on the Kubernetes persistent volume claims, make sure to have an eye on your costs and set the size for the volume via the respective environment variables accordingly. Even when deleting the Kuberentes PersistentVolume and PersistentVolumeClaim resources, the actual volumes might still exist on the cloud provider and have to be deleted manually.  
 
 ## After Installation
 


### PR DESCRIPTION
- [ ] Bugfix
- [ ] New Feature
- [x] Feature Improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other, please describe:

**Description:**
This PR addresses issue https://github.com/SAP/machine-learning-lab/issues/8. It was proposed to introduce a `LAB_SSL_ROOT` environment variable, that would allow the user to specify the directory on the host machine that contains a custom server certificate.

The extra variable was added and locally tested. It only affects docker local deployments and is not used for Kubernetes deployments. The documentation was updated to reflect the changes.

Some open questions:
- Should a similar variable LAB_TOS_ROOT be defined? Right now the tos must be placed in a volume named "lab-tos".
- Should the user provided configuration be checked somewhere?  For example, when specifying SERVICES_RUNTIME=k8s, the LAB_SSL_ROOT variable has no effect and a warning/error could be raised.

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/sap/machine-learning-lab/blob/master/CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.