### PR TITLE
Feature/custom workspace backend

### DIFF
--- a/backend/environment-lib/src/main/java/org/mltooling/core/lab/LabAdminApi.java
+++ b/backend/environment-lib/src/main/java/org/mltooling/core/lab/LabAdminApi.java
@@ -9,6 +9,8 @@ import org.mltooling.core.lab.model.LabEvent;
 import org.mltooling.core.lab.model.LabInfo;
 import org.mltooling.core.lab.model.LabProjectsStatistics;
 import org.mltooling.core.lab.model.LabUser;
+import org.mltooling.core.lab.model.LabService;
+
 
 public interface LabAdminApi {
 
@@ -22,6 +24,7 @@ public interface LabAdminApi {
   String PARAM_IS_ANONYMOUS = "anonymous";
   String PARAM_DRY_RUN = "dryrun";
   String PARAM_DAYS_THRESHOLD = "threshold";
+  String PARAM_DOCKER_IMAGE = "image";
 
   String METHOD_CHECK_WORKSPACE = "/workspace/check";
   String METHOD_RESET_WORKSPACE = "/workspace/reset";
@@ -38,9 +41,9 @@ public interface LabAdminApi {
   // ================ Methods ============================================= //
   // TODO why config with Object??
 
-  SingleValueFormat checkWorkspace(String workspaceId);
+  SingleValueFormat<LabService> checkWorkspace(String workspaceId);
 
-  SingleValueFormat resetWorkspace(String workspaceId);
+  SingleValueFormat resetWorkspace(String workspaceId, @Nullable String imageName);
 
   StatusMessageFormat resetAllWorkspaces();
 

--- a/backend/environment-lib/src/main/java/org/mltooling/core/lab/LabAdminApi.java
+++ b/backend/environment-lib/src/main/java/org/mltooling/core/lab/LabAdminApi.java
@@ -38,7 +38,7 @@ public interface LabAdminApi {
   // ================ Methods ============================================= //
   // TODO why config with Object??
 
-  StatusMessageFormat checkWorkspace(String workspaceId);
+  SingleValueFormat checkWorkspace(String workspaceId);
 
   SingleValueFormat resetWorkspace(String workspaceId);
 

--- a/backend/environment-lib/src/main/java/org/mltooling/core/lab/LabAdminApiClient.java
+++ b/backend/environment-lib/src/main/java/org/mltooling/core/lab/LabAdminApiClient.java
@@ -45,12 +45,12 @@ public class LabAdminApiClient extends AbstractApiClient<LabAdminApiClient> impl
   }
 
   @Override
-  public SingleValueFormat checkWorkspace(String workspaceId) {
+  public SingleValueFormat<LabService> checkWorkspace(String workspaceId) {
     return executeRequest(
         Unirest.get(getEndpointUrl() + METHOD_CHECK_WORKSPACE)
             .getHttpRequest()
             .queryString(PARAM_WORKSPACE_ID, workspaceId),
-        new TypeToken<SingleValueFormat>() {}.getType());
+        new TypeToken<SingleValueFormat<LabService>>() {}.getType());
   }
 
   @Override
@@ -86,12 +86,16 @@ public class LabAdminApiClient extends AbstractApiClient<LabAdminApiClient> impl
   }
 
   @Override
-  public SingleValueFormat<LabService> resetWorkspace(String workspaceId) {
-    return executeRequest(
-        Unirest.get(getEndpointUrl() + METHOD_RESET_WORKSPACE)
-            .getHttpRequest()
-            .queryString(PARAM_WORKSPACE_ID, workspaceId),
-        new TypeToken<SingleValueFormat<LabService>>() {}.getType());
+  public SingleValueFormat<LabService> resetWorkspace(String workspaceId, @Nullable String imageName) {
+    HttpRequest request = Unirest.get(getEndpointUrl() + METHOD_RESET_WORKSPACE)
+      .getHttpRequest()
+      .queryString(PARAM_WORKSPACE_ID, workspaceId);
+
+    if (imageName != null) {
+      request = request.queryString(PARAM_DOCKER_IMAGE, imageName);
+    }
+
+    return executeRequest(request, new TypeToken<SingleValueFormat<LabService>>() {}.getType());
   }
 
   @Override

--- a/backend/environment-lib/src/main/java/org/mltooling/core/lab/LabAdminApiClient.java
+++ b/backend/environment-lib/src/main/java/org/mltooling/core/lab/LabAdminApiClient.java
@@ -50,7 +50,7 @@ public class LabAdminApiClient extends AbstractApiClient<LabAdminApiClient> impl
         Unirest.get(getEndpointUrl() + METHOD_CHECK_WORKSPACE)
             .getHttpRequest()
             .queryString(PARAM_WORKSPACE_ID, workspaceId),
-        new TypeToken<StatusMessageFormat>() {}.getType());
+        new TypeToken<SingleValueFormat>() {}.getType());
   }
 
   @Override

--- a/backend/environment-lib/src/main/java/org/mltooling/core/lab/LabAdminApiClient.java
+++ b/backend/environment-lib/src/main/java/org/mltooling/core/lab/LabAdminApiClient.java
@@ -45,7 +45,7 @@ public class LabAdminApiClient extends AbstractApiClient<LabAdminApiClient> impl
   }
 
   @Override
-  public StatusMessageFormat checkWorkspace(String workspaceId) {
+  public SingleValueFormat checkWorkspace(String workspaceId) {
     return executeRequest(
         Unirest.get(getEndpointUrl() + METHOD_CHECK_WORKSPACE)
             .getHttpRequest()

--- a/backend/lab-service/docker-res/nginx.conf
+++ b/backend/lab-service/docker-res/nginx.conf
@@ -243,7 +243,12 @@ http {
                 -- if the container does not exist, call the /check endpoint from the Lab to load it
                 local res, error = http_connection:request_uri("http://" .. ngx.var.lab_namespace .. "-workspace-" .. ngx.var.id .. ngx.var.service_suffix .. ":8091/ping", {method = "GET"})
                 if error ~= nil or res == nil or res.status ~= 200 then
-                    local res, error  = http_connection:request_uri("http://127.0.0.1:8090{LAB_BASE_URL}/api/admin/workspace/check?id=" .. ngx.var.id, {method = "GET"})
+                    local res, error  = http_connection:request_uri("http://127.0.0.1:8090{LAB_BASE_URL}/api/admin/workspace/check?id=" .. ngx.var.id, {
+                        method = "GET",
+                        headers = {
+                            ["Authorization"] = jwt.get_token(),
+                        },
+                    })
 
                     if error ~= nil or res == nil or res.status ~= 200 then
                         ngx.log(ngx.ERR, "Request to check research container 'workspace-" .. ngx.var.id .. "' failed.")

--- a/backend/lab-service/src/main/java/org/mltooling/lab/api/LabAdminApiHandler.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/api/LabAdminApiHandler.java
@@ -232,6 +232,22 @@ public class LabAdminApiHandler extends AbstractApiHandler<LabAdminApiHandler>
         response.setErrorStatus("The workspace id parameter is empty.", HttpStatus.SC_BAD_REQUEST);
         return prepareResponse(response);
       }
+      user = AuthorizationManager.resolveUserName(user);
+
+      if (this.authProfile == null || user == null) {
+        response.setErrorStatus(
+          "Not authorized to check workspace: " + user, HttpStatus.SC_UNAUTHORIZED);
+        return prepareResponse(response);
+      }
+
+      if (!this.authProfile.getId().equalsIgnoreCase(user)
+        && !componentManager.getAuthManager().isAdmin(this.authProfile)) {
+        response.setErrorStatus(
+          "User " + this.authProfile.getId() + " is not allowed to check workspace: " + user,
+          HttpStatus.SC_UNAUTHORIZED);
+        return prepareResponse(response);
+      }
+
       log.debug("Checking workspace of " +  user);
       LabService workspaceService = componentManager.getServiceManger().checkWorkspace(user);
       if (workspaceService == null || !workspaceService.getIsHealthy()) {

--- a/backend/lab-service/src/main/java/org/mltooling/lab/api/LabAdminApiHandler.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/api/LabAdminApiHandler.java
@@ -245,6 +245,7 @@ public class LabAdminApiHandler extends AbstractApiHandler<LabAdminApiHandler>
       response.setSuccessfulStatus();
       //TODO differentiate between users that are running the default one and the other one.
       response.addMetadata("needsUpdate", false);
+      response.addMetadata("image", workspaceService.getDockerImage());
 //      response.addMetadata(
 //          "needsUpdate",
 //          !CoreService.WORKSPACE.getImage().equalsIgnoreCase(workspaceService.getDockerImage()));

--- a/backend/lab-service/src/main/java/org/mltooling/lab/api/LabAdminApiHandler.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/api/LabAdminApiHandler.java
@@ -169,7 +169,6 @@ public class LabAdminApiHandler extends AbstractApiHandler<LabAdminApiHandler>
    *     {WORKSPACE_SERVICE_PREFIX}
    */
   public SingleValueFormat<LabService> resetWorkspace(String user){
-    // TODO: Check which image was used by the user beforehand and reuse it by default
     return resetWorkspace(user, null);
   }
 

--- a/backend/lab-service/src/main/java/org/mltooling/lab/api/LabAdminApiHandler.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/api/LabAdminApiHandler.java
@@ -61,8 +61,8 @@ public class LabAdminApiHandler extends AbstractApiHandler<LabAdminApiHandler>
       // reset all workspaces
       for (String user : componentManager.getAuthManager().getProfileIds()) {
         try {
-          String imageName = null; //TODO: Get which image is used right now
-          LabService workspaceService = componentManager.getServiceManger().resetWorkspace(user, imageName);
+          LabService workspaceService =
+              componentManager.getServiceManger().resetWorkspace(user, null);
           if (workspaceService == null || !workspaceService.getIsHealthy()) {
             log.warn("Could not check workspace service availability for " + user);
           }
@@ -168,7 +168,7 @@ public class LabAdminApiHandler extends AbstractApiHandler<LabAdminApiHandler>
    * @param user - id which should be used to identify the container. Will be prefixed with
    *     {WORKSPACE_SERVICE_PREFIX}
    */
-  public SingleValueFormat<LabService> resetWorkspace(String user){
+  public SingleValueFormat<LabService> resetWorkspace(String user) {
     return resetWorkspace(user, null);
   }
 
@@ -199,7 +199,8 @@ public class LabAdminApiHandler extends AbstractApiHandler<LabAdminApiHandler>
         return prepareResponse(response);
       }
 
-      LabService workspaceService = componentManager.getServiceManger().resetWorkspace(user, imageName);
+      LabService workspaceService =
+          componentManager.getServiceManger().resetWorkspace(user, imageName);
       if (workspaceService == null || !workspaceService.getIsHealthy()) {
         log.error("Could not check service availability.");
         response.setErrorStatus(
@@ -236,19 +237,19 @@ public class LabAdminApiHandler extends AbstractApiHandler<LabAdminApiHandler>
 
       if (this.authProfile == null || user == null) {
         response.setErrorStatus(
-          "Not authorized to check workspace: " + user, HttpStatus.SC_UNAUTHORIZED);
+            "Not authorized to check workspace: " + user, HttpStatus.SC_UNAUTHORIZED);
         return prepareResponse(response);
       }
 
       if (!this.authProfile.getId().equalsIgnoreCase(user)
-        && !componentManager.getAuthManager().isAdmin(this.authProfile)) {
+          && !componentManager.getAuthManager().isAdmin(this.authProfile)) {
         response.setErrorStatus(
-          "User " + this.authProfile.getId() + " is not allowed to check workspace: " + user,
-          HttpStatus.SC_UNAUTHORIZED);
+            "User " + this.authProfile.getId() + " is not allowed to check workspace: " + user,
+            HttpStatus.SC_UNAUTHORIZED);
         return prepareResponse(response);
       }
 
-      log.debug("Checking workspace of " +  user);
+      log.debug("Checking workspace of " + user);
       LabService workspaceService = componentManager.getServiceManger().checkWorkspace(user);
       if (workspaceService == null || !workspaceService.getIsHealthy()) {
         log.warn("Could not check service availability for user: " + user);
@@ -259,11 +260,12 @@ public class LabAdminApiHandler extends AbstractApiHandler<LabAdminApiHandler>
 
       response.setSuccessfulStatus();
       response.setData(workspaceService);
-      //TODO differentiate between users that are running the default one and the other one.
+      // TODO differentiate between users that are running the default one and the other one.
       response.addMetadata("needsUpdate", false);
-//      response.addMetadata(
-//          "needsUpdate",
-//          !CoreService.WORKSPACE.getImage().equalsIgnoreCase(workspaceService.getDockerImage()));
+      //      response.addMetadata(
+      //          "needsUpdate",
+      //
+      // !CoreService.WORKSPACE.getImage().equalsIgnoreCase(workspaceService.getDockerImage()));
       return prepareResponse(response);
     } catch (Exception e) {
       log.debug(e.getMessage(), e);

--- a/backend/lab-service/src/main/java/org/mltooling/lab/api/LabAdminApiHandler.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/api/LabAdminApiHandler.java
@@ -226,8 +226,8 @@ public class LabAdminApiHandler extends AbstractApiHandler<LabAdminApiHandler>
    * @return
    */
   @Override
-  public StatusMessageFormat checkWorkspace(String user) {
-    StatusMessageFormat response = new StatusMessageFormat();
+  public SingleValueFormat<LabService> checkWorkspace(String user) {
+    SingleValueFormat<LabService> response = new SingleValueFormat<>();
     try {
       if (StringUtils.isNullOrEmpty(user)) {
         response.setErrorStatus("The workspace id parameter is empty.", HttpStatus.SC_BAD_REQUEST);
@@ -243,9 +243,9 @@ public class LabAdminApiHandler extends AbstractApiHandler<LabAdminApiHandler>
       }
 
       response.setSuccessfulStatus();
+      response.setData(workspaceService);
       //TODO differentiate between users that are running the default one and the other one.
       response.addMetadata("needsUpdate", false);
-      response.addMetadata("image", workspaceService.getDockerImage());
 //      response.addMetadata(
 //          "needsUpdate",
 //          !CoreService.WORKSPACE.getImage().equalsIgnoreCase(workspaceService.getDockerImage()));

--- a/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
@@ -59,7 +59,7 @@ public class LabAdminEndpoint extends AbstractApiEndpoint<LabAdminEndpoint> {
       value =
           "Checks whether a workspace container for the passed id already exists. If not, a new"
               + " one is created & started.",
-      response = StatusMessageFormat.class)
+      response = LabServiceResponse.class)
   @Produces(MediaType.APPLICATION_JSON)
   @Pac4JSecurity(ignore = true)
   public Response checkWorkspace(

--- a/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
@@ -163,7 +163,7 @@ public class LabAdminEndpoint extends AbstractApiEndpoint<LabAdminEndpoint> {
   @ApiOperation(
       value =
           "Resets a workspace. Removes the container (keeps all persisted data) and starts a new"
-              + " one.  When specified an image, it is used this image instead",
+              + " one.  If an image is specified, it will be used instead of the default image.",
       response = LabServiceResponse.class)
   @Produces(MediaType.APPLICATION_JSON)
   @Pac4JSecurity(

--- a/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
@@ -17,6 +17,7 @@ import org.mltooling.core.service.utils.AbstractApiEndpoint;
 import org.mltooling.core.service.utils.UnifiedResponseFactory;
 import org.mltooling.lab.api.LabAdminApiHandler;
 import org.mltooling.lab.authorization.AuthorizationManager;
+import org.mltooling.lab.services.CoreService;
 import org.pac4j.jax.rs.annotations.Pac4JProfile;
 import org.pac4j.jax.rs.annotations.Pac4JSecurity;
 import org.pac4j.mongo.profile.MongoProfile;
@@ -178,7 +179,7 @@ public class LabAdminEndpoint extends AbstractApiEndpoint<LabAdminEndpoint> {
       @Pac4JProfile MongoProfile commonProfile,
       @BeanParam DefaultHeaderFields defaultHeaders) {
     adminApiHandler.setAuthProfile(commonProfile);
-    return UnifiedResponseFactory.getResponse(adminApiHandler.resetWorkspace(id));
+    return UnifiedResponseFactory.getResponse(adminApiHandler.resetWorkspace(id, image));
   }
 
   @GET

--- a/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
@@ -180,7 +180,7 @@ public class LabAdminEndpoint extends AbstractApiEndpoint<LabAdminEndpoint> {
       authorizers = AuthorizationManager.AUTHORIZER_IS_AUTHENTICATED)
   public Response resetWorkspace(
       @QueryParam(LabAdminApi.PARAM_WORKSPACE_ID) String id,
-      @ApiParam(value = "Image Name", required = false) @QueryParam(LabApi.PARAM_DOCKER_IMAGE)
+      @ApiParam(value = "Image Name", required = false) @QueryParam(LabAdminApi.PARAM_DOCKER_IMAGE)
           String image,
       @Pac4JProfile MongoProfile commonProfile,
       @BeanParam DefaultHeaderFields defaultHeaders) {

--- a/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
@@ -61,11 +61,17 @@ public class LabAdminEndpoint extends AbstractApiEndpoint<LabAdminEndpoint> {
               + " one is created & started.",
       response = LabServiceResponse.class)
   @Produces(MediaType.APPLICATION_JSON)
-  @Pac4JSecurity(ignore = true)
+  @Pac4JSecurity(
+    clients = {
+      AuthorizationManager.PAC4J_CLIENT_COOKIE,
+      AuthorizationManager.PAC4J_CLIENT_HEADER
+    },
+    authorizers = AuthorizationManager.AUTHORIZER_IS_AUTHENTICATED)
   public Response checkWorkspace(
       @QueryParam(LabAdminApi.PARAM_WORKSPACE_ID) String id,
+      @Pac4JProfile MongoProfile commonProfile,
       @BeanParam DefaultHeaderFields defaultHeaders) {
-    // TODO should this method be secured?
+    adminApiHandler.setAuthProfile(commonProfile);
     return UnifiedResponseFactory.getResponse(adminApiHandler.checkWorkspace(id));
   }
 

--- a/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
@@ -62,11 +62,11 @@ public class LabAdminEndpoint extends AbstractApiEndpoint<LabAdminEndpoint> {
       response = LabServiceResponse.class)
   @Produces(MediaType.APPLICATION_JSON)
   @Pac4JSecurity(
-    clients = {
-      AuthorizationManager.PAC4J_CLIENT_COOKIE,
-      AuthorizationManager.PAC4J_CLIENT_HEADER
-    },
-    authorizers = AuthorizationManager.AUTHORIZER_IS_AUTHENTICATED)
+      clients = {
+        AuthorizationManager.PAC4J_CLIENT_COOKIE,
+        AuthorizationManager.PAC4J_CLIENT_HEADER
+      },
+      authorizers = AuthorizationManager.AUTHORIZER_IS_AUTHENTICATED)
   public Response checkWorkspace(
       @QueryParam(LabAdminApi.PARAM_WORKSPACE_ID) String id,
       @Pac4JProfile MongoProfile commonProfile,
@@ -181,7 +181,7 @@ public class LabAdminEndpoint extends AbstractApiEndpoint<LabAdminEndpoint> {
   public Response resetWorkspace(
       @QueryParam(LabAdminApi.PARAM_WORKSPACE_ID) String id,
       @ApiParam(value = "Image Name", required = false) @QueryParam(LabApi.PARAM_DOCKER_IMAGE)
-        String image,
+          String image,
       @Pac4JProfile MongoProfile commonProfile,
       @BeanParam DefaultHeaderFields defaultHeaders) {
     adminApiHandler.setAuthProfile(commonProfile);

--- a/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/endpoints/LabAdminEndpoint.java
@@ -10,6 +10,7 @@ import org.mltooling.core.api.format.SingleValueFormat;
 import org.mltooling.core.api.format.StatusMessageFormat;
 import org.mltooling.core.api.format.ValueListFormat;
 import org.mltooling.core.lab.LabAdminApi;
+import org.mltooling.core.lab.LabApi;
 import org.mltooling.core.lab.model.*;
 import org.mltooling.core.service.params.DefaultHeaderFields;
 import org.mltooling.core.service.utils.AbstractApiEndpoint;
@@ -161,7 +162,7 @@ public class LabAdminEndpoint extends AbstractApiEndpoint<LabAdminEndpoint> {
   @ApiOperation(
       value =
           "Resets a workspace. Removes the container (keeps all persisted data) and starts a new"
-              + " one.",
+              + " one.  When specified an image, it is used this image instead",
       response = LabServiceResponse.class)
   @Produces(MediaType.APPLICATION_JSON)
   @Pac4JSecurity(
@@ -172,6 +173,8 @@ public class LabAdminEndpoint extends AbstractApiEndpoint<LabAdminEndpoint> {
       authorizers = AuthorizationManager.AUTHORIZER_IS_AUTHENTICATED)
   public Response resetWorkspace(
       @QueryParam(LabAdminApi.PARAM_WORKSPACE_ID) String id,
+      @ApiParam(value = "Image Name", required = false) @QueryParam(LabApi.PARAM_DOCKER_IMAGE)
+        String image,
       @Pac4JProfile MongoProfile commonProfile,
       @BeanParam DefaultHeaderFields defaultHeaders) {
     adminApiHandler.setAuthProfile(commonProfile);

--- a/backend/lab-service/src/main/java/org/mltooling/lab/services/AbstractServiceManager.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/services/AbstractServiceManager.java
@@ -332,12 +332,12 @@ public abstract class AbstractServiceManager {
     // remove workspace without volumes
     String previousUsedImage = shutdownWorkspace(user);
 
-    if (previousUsedImage == null){
+    if (previousUsedImage == null) {
       previousUsedImage = CoreService.WORKSPACE.getImage();
       log.info("Unable to retrieve previous used image for user: " + user);
     }
 
-    if (imageName == null){
+    if (imageName == null) {
       imageName = previousUsedImage;
       log.debug("No image provided, using previously used image: " + imageName);
     }
@@ -424,8 +424,9 @@ public abstract class AbstractServiceManager {
   }
 
   /** Create a workspace service for a given user. */
-  public DockerDeploymentConfig createWorkspaceService(String user, @Nullable String imageName) throws Exception {
-    if (imageName == null){
+  public DockerDeploymentConfig createWorkspaceService(String user, @Nullable String imageName)
+      throws Exception {
+    if (imageName == null) {
       imageName = CoreService.WORKSPACE.getImage();
       log.debug("No image was specified. Using default workspace image");
     }

--- a/backend/lab-service/src/main/java/org/mltooling/lab/services/AbstractServiceManager.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/services/AbstractServiceManager.java
@@ -334,12 +334,12 @@ public abstract class AbstractServiceManager {
 
     if (previousUsedImage == null){
       previousUsedImage = CoreService.WORKSPACE.getImage();
-      log.info("Unable to retrieve previous used image");
+      log.info("Unable to retrieve previous used image for user: " + user);
     }
 
     if (imageName == null){
       imageName = previousUsedImage;
-      log.info("Not image given, used previous used image: " + imageName);
+      log.debug("No image provided, using previously used image: " + imageName);
     }
 
     Thread.sleep(2000);
@@ -427,10 +427,9 @@ public abstract class AbstractServiceManager {
   public DockerDeploymentConfig createWorkspaceService(String user, @Nullable String imageName) throws Exception {
     if (imageName == null){
       imageName = CoreService.WORKSPACE.getImage();
-      log.info("No image was specified. Using default workspace image");
+      log.debug("No image was specified. Using default workspace image");
     }
     String dockerName = getWorkspaceName(user);
-    log.info("Create Workspace Service, imagename: " + imageName);
     String jupyterBaseUrl = "workspace/id/" + user + "/";
     if (!StringUtils.isNullOrEmpty(LabConfig.LAB_BASE_URL)) {
       jupyterBaseUrl = LabConfig.LAB_BASE_URL + "/" + jupyterBaseUrl;

--- a/backend/lab-service/src/main/java/org/mltooling/lab/services/AbstractServiceManager.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/services/AbstractServiceManager.java
@@ -10,6 +10,8 @@ import com.spotify.docker.client.messages.ImageInfo;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.validation.constraints.Null;
+
 import org.mltooling.core.lab.model.LabJob;
 import org.mltooling.core.lab.model.LabService;
 import org.mltooling.core.utils.CryptoUtils;
@@ -268,7 +270,10 @@ public abstract class AbstractServiceManager {
 
   /** Check if workspace container for user already exists and, if not, creates a new one. */
   public LabService checkWorkspace(String user) throws Exception {
+    return checkWorkspace(user, null);
+  }
 
+  public LabService checkWorkspace(String user, @Nullable String imageName) throws Exception {
     user = AuthorizationManager.resolveUserName(user);
 
     if (ComponentManager.INSTANCE.getAuthManager().getUser(user) == null) {
@@ -289,22 +294,22 @@ public abstract class AbstractServiceManager {
       return workspaceService;
     }
 
-    return deployService(createWorkspaceService(user));
+    return deployService(createWorkspaceService(user, imageName));
   }
 
-  public boolean shutdownWorkspace(String user) throws Exception {
+  public String shutdownWorkspace(String user) throws Exception {
     if (ComponentManager.INSTANCE.getAuthManager().getUser(user) == null) {
       throw new Exception("User " + user + " does not exist.");
     }
 
     String workspaceName = getWorkspaceName(user);
     LabService workspaceService = getService(workspaceName);
-
+    String dockerImage = workspaceService.getDockerImage();
     if (workspaceService == null) {
       throw new Exception("Could not find workspace for user: " + user);
     }
-
-    return deleteService(workspaceService.getDockerName(), false, null);
+    deleteService(workspaceService.getDockerName(), false, null);
+    return dockerImage;
   }
 
   public boolean deleteWorkspace(String user) throws Exception {
@@ -323,14 +328,24 @@ public abstract class AbstractServiceManager {
     return deleteService(workspaceService.getDockerName(), true, null);
   }
 
-  public LabService resetWorkspace(String user) throws Exception {
+  public LabService resetWorkspace(String user, String imageName) throws Exception {
     // remove workspace without volumes
-    shutdownWorkspace(user);
+    String previousUsedImage = shutdownWorkspace(user);
+
+    if (previousUsedImage == null){
+      previousUsedImage = CoreService.WORKSPACE.getImage();
+      log.info("Unable to retrieve previous used image");
+    }
+
+    if (imageName == null){
+      imageName = previousUsedImage;
+      log.info("Not image given, used previous used image: " + imageName);
+    }
 
     Thread.sleep(2000);
 
     // start workspace again
-    return checkWorkspace(user);
+    return checkWorkspace(user, imageName);
   }
 
   /** Install Lab - this script is always called in local docker mode only */
@@ -409,9 +424,13 @@ public abstract class AbstractServiceManager {
   }
 
   /** Create a workspace service for a given user. */
-  public DockerDeploymentConfig createWorkspaceService(String user) throws Exception {
+  public DockerDeploymentConfig createWorkspaceService(String user, @Nullable String imageName) throws Exception {
+    if (imageName == null){
+      imageName = CoreService.WORKSPACE.getImage();
+      log.info("No image was specified. Using default workspace image");
+    }
     String dockerName = getWorkspaceName(user);
-
+    log.info("Create Workspace Service, imagename: " + imageName);
     String jupyterBaseUrl = "workspace/id/" + user + "/";
     if (!StringUtils.isNullOrEmpty(LabConfig.LAB_BASE_URL)) {
       jupyterBaseUrl = LabConfig.LAB_BASE_URL + "/" + jupyterBaseUrl;
@@ -449,7 +468,7 @@ public abstract class AbstractServiceManager {
       envVars.put(LabConfig.ENV_NAME_NO_PROXY, LabConfig.ENV_NO_PROXY);
     }
 
-    String dockerImage = CoreService.WORKSPACE.getImage();
+    String dockerImage = imageName;
 
     final String volumePath = "/workspace";
     DockerDeploymentConfig workspaceConfig =

--- a/backend/lab-service/src/main/java/org/mltooling/lab/services/managers/DockerServiceManager.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/services/managers/DockerServiceManager.java
@@ -395,8 +395,8 @@ public class DockerServiceManager extends AbstractServiceManager {
   }
 
   @Override
-  public DockerDeploymentConfig createWorkspaceService(String user) throws Exception {
-    DockerDeploymentConfig workspaceDeployment = super.createWorkspaceService(user);
+  public DockerDeploymentConfig createWorkspaceService(String user, String imageName) throws Exception {
+    DockerDeploymentConfig workspaceDeployment = super.createWorkspaceService(user, imageName);
 
     if (!StringUtils.isNullOrEmpty(LabConfig.HOST_ROOT_WORKSPACE_DATA_MOUNT_PATH)) {
       // if workspace data mount is configured, use it

--- a/backend/lab-service/src/main/java/org/mltooling/lab/services/managers/DockerServiceManager.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/services/managers/DockerServiceManager.java
@@ -395,7 +395,8 @@ public class DockerServiceManager extends AbstractServiceManager {
   }
 
   @Override
-  public DockerDeploymentConfig createWorkspaceService(String user, String imageName) throws Exception {
+  public DockerDeploymentConfig createWorkspaceService(String user, String imageName)
+      throws Exception {
     DockerDeploymentConfig workspaceDeployment = super.createWorkspaceService(user, imageName);
 
     if (!StringUtils.isNullOrEmpty(LabConfig.HOST_ROOT_WORKSPACE_DATA_MOUNT_PATH)) {

--- a/backend/lab-service/src/main/java/org/mltooling/lab/services/managers/KubernetesServiceManager.java
+++ b/backend/lab-service/src/main/java/org/mltooling/lab/services/managers/KubernetesServiceManager.java
@@ -580,8 +580,8 @@ public class KubernetesServiceManager extends AbstractServiceManager {
   }
 
   @Override
-  public DockerDeploymentConfig createWorkspaceService(String user) throws Exception {
-    DockerDeploymentConfig workspaceDeployment = super.createWorkspaceService(user);
+  public DockerDeploymentConfig createWorkspaceService(String user, String imageName) throws Exception {
+    DockerDeploymentConfig workspaceDeployment = super.createWorkspaceService(user, imageName);
 
     if (!LabConfig.IS_MANAGED_KUBERNETES_CLUSTER) {
       // connect NFS container

--- a/backend/lab-service/src/test/java/org/mltooling/lab/LabAdminApiTest.java
+++ b/backend/lab-service/src/test/java/org/mltooling/lab/LabAdminApiTest.java
@@ -1,0 +1,343 @@
+package org.mltooling.lab;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.options.Options;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.*;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.mltooling.core.api.format.SingleValueFormat;
+import org.mltooling.core.api.utils.ApiUtils;
+import org.mltooling.core.lab.*;
+import org.mltooling.core.lab.model.LabProject;
+import org.mltooling.core.lab.model.LabProjectConfig;
+import org.mltooling.core.lab.model.LabService;
+import org.mltooling.core.service.tests.IntegrationTest;
+import org.mltooling.core.service.tests.LocalDockerLauncher;
+import org.mltooling.core.utils.StringUtils;
+import org.mltooling.core.utils.SystemUtils;
+import org.mltooling.lab.authorization.AuthorizationManager;
+import org.mltooling.lab.services.CoreService;
+import org.mltooling.lab.services.managers.DockerServiceManager;
+import org.mltooling.lab.services.managers.KubernetesServiceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Category(IntegrationTest.class)
+public class LabAdminApiTest {
+
+  // ================ Constants =========================================== //
+  private static final Logger log = LoggerFactory.getLogger(LabAdminApiTest.class);
+
+  private static final long SLEEP = 5000;
+
+  private static long MAX_WAIT_TIME = TimeUnit.MINUTES.toMillis(5);
+  private static long WAIT_INTERVALS = TimeUnit.SECONDS.toMillis(10);
+
+  private static final String ADMIN_USER = "foo";
+  private static final String ADMIN_PASSWORD = "bar";
+
+  private static final String TEST_USER_ID = "test";
+  private static final String TEST_USER_PASSWORD = "test";
+
+  private static final String NEW_WORKSPACE_IMAGE = "new-workspace:latest";
+  private static final String DEFAULT_WORKSPACE_IMAGE = CoreService.WORKSPACE.getImage();
+
+
+  // ================ Members ============================================= //
+  @Rule public final LocalDockerLauncher dockerLauncher;
+  @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  // @ClassRule
+  // set this namespace so that the .cleanup method clean lab-test resources and not
+  // actual resources
+  // Comment the other environment variables in if you start the test from within the IDE; otherwise
+  // set it on the host machine / container.
+  // public static final EnvironmentVariables environmentVariables =
+  //     new EnvironmentVariables()
+  //         .set(LabConfig.ENV_NAME_LAB_NAMESPACE, "lab-test")
+  //         .set(LabConfig.ENV_NAME_K8S_NAMESPACE, "ml-test");
+  private final String DEFAULT_HOST = SystemUtils.getEnvVar("SERVICE_HOST", "localhost");
+  // by default use a port > 30000 so that it also works in Kubernetes mode (Kubernetes service ports must
+  // by default be >30000)
+  // private static final int LAB_PORT =
+  //   StringUtils.isNullOrEmpty(SystemUtils.getEnvVar(LabConfig.ENV_NAME_LAB_PORT)) ? 30002 : Integer.parseInt(SystemUtils.getEnvVar(LabConfig.ENV_NAME_LAB_PORT));
+  private final int LAB_PORT = StringUtils.isNullOrEmpty(LabConfig.LAB_PORT) ? 30002 : Integer.parseInt(LabConfig.LAB_PORT);
+  private final int LAB_SERVICE_PORT =
+    Integer.parseInt(SystemUtils.getEnvVar("LAB_SERVICE_PORT", "" + this.LAB_PORT));
+  private final int DEFAULT_PROJECT_SERVICES_SIZE = 0; // no more initial project services
+
+  private final Boolean IS_KIND_CLUSTER =
+    Boolean.parseBoolean(SystemUtils.getEnvVar("IS_KIND_CLUSTER", "False"));
+
+  private LabApi labApi;
+  private LabAuthApi authorizationApi;
+  private LabAdminApi labAdminApiAdminUser;
+  private LabAdminApi labAdminApiNonAdminUser;
+
+  private String testProject1;
+  private String testProject2;
+
+  private String serviceUrl;
+  private String adminApiToken;
+  private String adminAppToken;
+
+  private String userApiToken;
+  private String userAppToken;
+
+  // ================ Constructors & Main ================================= //
+  public LabAdminApiTest() throws Exception {
+    resetUnirest();
+    // currently service name needs to be "lab-service", otherwise the lab service (added in
+    // core service) cannot be found
+    final String dockerImage = LabConfig.BACKEND_SERVICE_IMAGE;
+
+    if (ComponentManager.INSTANCE.isKubernetesRuntime()) {
+      Map<String, String> envVars = new HashMap<>();
+      envVars.put(LabConfig.ENV_NAME_SERVICES_RUNTIME, LabConfig.SERVICES_RUNTIME);
+      envVars.put(LabConfig.ENV_NAME_SERVICES_CPU_LIMIT, "1");
+      envVars.put(LabConfig.ENV_NAME_SERVICES_MEMORY_LIMIT, "2");
+      envVars.put(LabConfig.ENV_NAME_K8S_NAMESPACE, LabConfig.K8S_NAMESPACE);
+      envVars.put(
+        LabConfig.ENV_NAME_HOST_ROOT_DATA_MOUNT_PATH, LabConfig.HOST_ROOT_DATA_MOUNT_PATH);
+      this.dockerLauncher =
+        new LocalDockerLauncher(DEFAULT_HOST, LAB_SERVICE_PORT, LAB_PORT, envVars, dockerImage, true);
+    } else {
+      Map<String, String> envVars = new HashMap<>();
+      // Have to explicitly pass the workspace image as the backend image could be built with a different
+      // SERVICE_VERSION, which makes the workspace tests fail
+      envVars.put(LabConfig.ENV_NAME_WORKSPACE_IMAGE, LabConfig.WORKSPACE_IMAGE);
+      this.dockerLauncher =
+        new LocalDockerLauncher(DEFAULT_HOST, LAB_SERVICE_PORT, LAB_PORT, envVars, dockerImage, false);
+    }
+
+    Thread.sleep(SLEEP * 3);
+  }
+
+  // ================ Methods for/from SuperClass / Interfaces ============ //
+  @Before
+  public void setUp() throws Exception {
+    // Connect via API client to Service
+    // final String SERVICE_URL = "http://" + DEFAULT_HOST + ":" + LAB_SERVICE_PORT;
+    serviceUrl = "http://" + DEFAULT_HOST + ":" + LAB_SERVICE_PORT;
+    adminAppToken = getAdminToken(serviceUrl);
+    LabAuthApiClient authApi = new LabAuthApiClient(serviceUrl, adminAppToken);
+    adminApiToken = authApi.createApiToken(ADMIN_USER).getData();
+
+    log.info("Create Test User");
+    authApi.createUser(TEST_USER_ID, TEST_USER_PASSWORD);
+    log.info("Login Test User");
+    userAppToken = authApi.loginUser(TEST_USER_ID, TEST_USER_PASSWORD).getData();
+
+    log.info("Admin Token: " + adminApiToken);
+    labApi = new LabApiClient(serviceUrl, adminApiToken);
+    labAdminApiAdminUser =  new LabAdminApiClient(serviceUrl, adminApiToken);
+
+    testProject1 = "test-" + System.currentTimeMillis();
+    SingleValueFormat<LabProject> response =
+      labApi.createProject(new LabProjectConfig(testProject1));
+
+    resetUnirest();
+    Assume.assumeThat(response.getMetadata("status"), not(500));
+
+    // Add test user to project
+    userAppToken = authApi.addUserToProject(TEST_USER_ID, testProject1).getData();
+    userApiToken = authApi.createApiToken(TEST_USER_ID).getData();
+    labAdminApiNonAdminUser =  new LabAdminApiClient(serviceUrl, userApiToken);
+
+    log.info("User Api Token: " + userApiToken);
+
+    testProject2 = "test-" + System.currentTimeMillis();
+    response = labApi.createProject(new LabProjectConfig(testProject2));
+    Assume.assumeThat(response.getMetadata("status"), not(500));
+
+    try{
+      this.dockerLauncher.tagDockerImage(LabConfig.WORKSPACE_IMAGE, NEW_WORKSPACE_IMAGE);
+    } catch (Throwable throwable) {
+      throwable.printStackTrace();
+    }
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    log.info("Deleting all projects");
+    labApi.deleteProject(testProject1).isSuccessful();
+    labApi.deleteProject(testProject2).isSuccessful();
+    log.info("Delete user");
+    new LabAuthApiClient(serviceUrl, adminAppToken).deleteUser(TEST_USER_ID);
+    new LabAuthApiClient(serviceUrl, adminAppToken).deleteUser(ADMIN_USER);
+    Thread.sleep(SLEEP * 2);
+  }
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    if (ComponentManager.INSTANCE.isKubernetesRuntime()) {
+      try {
+        KubernetesServiceManager.cleanUpLab();
+        Thread.sleep(SLEEP * 4); // sleep as the cleanup happens asynchronously
+      } catch (Exception e) {
+        log.error(e.getMessage());
+      }
+    } else {
+      DockerServiceManager.cleanUpLab(false);
+    }
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    if (ComponentManager.INSTANCE.isKubernetesRuntime()) {
+      try {
+        KubernetesServiceManager.cleanUpLab();
+        Thread.sleep(SLEEP * 2); // sleep as the cleanup happens asynchronously
+      } catch (Exception e) {
+        log.error(e.getMessage());
+      }
+    } else {
+      DockerServiceManager.cleanUpLab(false);
+    }
+
+    log.info("Finished tests and cleaned up");
+  }
+
+  @Test
+  public void testWorkspaceHandling() throws Exception {
+    log.info("Checking creation of default workspaces");
+    // Admin should be able to check it's  own workspace
+    SingleValueFormat<LabService>  response =  labAdminApiAdminUser.checkWorkspace(ADMIN_USER);
+    assertThat(response.getStatus(), is(equalTo(200)));
+    assertThat(response.getData().getDockerImage(), is(equalTo(DEFAULT_WORKSPACE_IMAGE)));
+    // A  user should be able to check  it's own workspace
+    SingleValueFormat<LabService>  responseTestUser =  labAdminApiNonAdminUser.checkWorkspace(TEST_USER_ID);
+    assertThat(responseTestUser.getStatus(), is(equalTo(200)));
+    assertThat(responseTestUser.getData().getDockerImage(), is(equalTo(DEFAULT_WORKSPACE_IMAGE)));
+    // Admin should be able to check another user's workspace
+    response =  labAdminApiAdminUser.checkWorkspace(TEST_USER_ID);
+    assertThat(response.getStatus(), is(equalTo(200)));
+    assertThat(response.getData().getDockerImage(), is(equalTo(DEFAULT_WORKSPACE_IMAGE)));
+    // A  user shouldn't be able to check another user workspace
+    responseTestUser =  labAdminApiNonAdminUser.checkWorkspace(ADMIN_USER);
+    assertThat(responseTestUser.getStatus(), is(equalTo(401)));
+
+    log.info("Checking creation of custom workspaces");
+    // A  user should be able to create a custom workspace for himself
+    responseTestUser =  labAdminApiNonAdminUser.resetWorkspace(TEST_USER_ID, NEW_WORKSPACE_IMAGE);
+    assertThat(responseTestUser.getStatus(), is(equalTo(200)));
+    assertThat(responseTestUser.getData().getDockerImage(), is(equalTo(NEW_WORKSPACE_IMAGE)));
+    // Checking the workspace shouldn't change the image
+    responseTestUser =  labAdminApiNonAdminUser.checkWorkspace(TEST_USER_ID);
+    assertThat(responseTestUser.getStatus(), is(equalTo(200)));
+    assertThat(responseTestUser.getData().getDockerImage(), is(equalTo(NEW_WORKSPACE_IMAGE)));
+    // Resetting the workspace without specifying an image should spawn back the previously used image
+    responseTestUser =  labAdminApiNonAdminUser.resetWorkspace(TEST_USER_ID, null);
+    assertThat(responseTestUser.getStatus(), is(equalTo(200)));
+    assertThat(responseTestUser.getData().getDockerImage(), is(equalTo(NEW_WORKSPACE_IMAGE)));
+    responseTestUser =  labAdminApiNonAdminUser.checkWorkspace(TEST_USER_ID);
+    assertThat(responseTestUser.getStatus(), is(equalTo(200)));
+    assertThat(responseTestUser.getData().getDockerImage(), is(equalTo(NEW_WORKSPACE_IMAGE)));
+
+    // A user shouldn't be able to  change the workspace of somebody else
+    responseTestUser =  labAdminApiNonAdminUser.resetWorkspace(ADMIN_USER, null);
+    assertThat(responseTestUser.getStatus(), is(equalTo(401)));
+    responseTestUser =  labAdminApiNonAdminUser.resetWorkspace(ADMIN_USER, NEW_WORKSPACE_IMAGE);
+    assertThat(responseTestUser.getStatus(), is(equalTo(401)));
+
+
+    // Admin should be able to change the workspace of somebody else
+    response =  labAdminApiAdminUser.resetWorkspace(ADMIN_USER, NEW_WORKSPACE_IMAGE);
+    assertThat(response.getStatus(), is(equalTo(200)));
+    assertThat(response.getData().getDockerImage(), is(equalTo(NEW_WORKSPACE_IMAGE)));
+    response =  labAdminApiAdminUser.resetWorkspace(ADMIN_USER, DEFAULT_WORKSPACE_IMAGE);
+    assertThat(response.getStatus(), is(equalTo(200)));
+    assertThat(response.getData().getDockerImage(), is(equalTo(DEFAULT_WORKSPACE_IMAGE)));
+
+    // Test if workspace is reachable via URL
+    String urlAdminWorkspace =
+      this.serviceUrl
+        + "/workspace/id/"
+        + ADMIN_USER
+        + "/tree";
+
+    // this call requires the Bearer token
+    log.info("Requesting with admin token: " + urlAdminWorkspace);
+    Integer status =
+      Unirest.get(urlAdminWorkspace)
+        .header(ApiUtils.AUTHORIZATION_HEADER, "Bearer " + adminAppToken)
+        .getHttpRequest()
+        .asString()
+        .getStatus();
+    assertThat(status, is(equalTo(200)));
+    log.info("Requesting with user token: " + urlAdminWorkspace);
+    status =
+      Unirest.get(urlAdminWorkspace)
+        .header(ApiUtils.AUTHORIZATION_HEADER, "Bearer " + userAppToken)
+        .getHttpRequest()
+        .asString()
+        .getStatus();
+    assertThat(status, is(equalTo(401)));
+
+
+    // Test if workspace is reachable via URL
+    String urlUserWorkspace =
+      this.serviceUrl
+        + "/workspace/id/"
+        + TEST_USER_ID
+        + "/tree";
+
+    // this call requires the Bearer token
+    log.info("Requesting with user Token: " + urlUserWorkspace);
+    status =
+      Unirest.get(urlUserWorkspace)
+        .header(ApiUtils.AUTHORIZATION_HEADER, "Bearer " + userAppToken)
+        .getHttpRequest()
+        .asString()
+        .getStatus();
+    assertThat(status, is(equalTo(200)));
+    // this call requires the Bearer token
+    log.info("Requesting with admin Token: " + urlUserWorkspace);
+    status =
+      Unirest.get(urlUserWorkspace)
+        .header(ApiUtils.AUTHORIZATION_HEADER, "Bearer " + adminAppToken)
+        .getHttpRequest()
+        .asString()
+        .getStatus();
+    assertThat(status, is(equalTo(200)));
+
+  }
+
+
+  // ================ Private Methods ===================================== //
+  private String getAdminToken(String serviceUrl) {
+    // all API calls in this test will be made via this user / the user's token
+    authorizationApi = new LabAuthApiClient(serviceUrl);
+    authorizationApi.createAdminUser(
+      ADMIN_USER, ADMIN_PASSWORD, AuthorizationManager.DEFAULT_JWT_SECRET);
+    return authorizationApi.loginUser(ADMIN_USER, ADMIN_PASSWORD).getData();
+  }
+
+  /**
+   * This is somehow necessary, as Unirest will otherwise not accept '127.0.0.1' or 'localhost'
+   * whereas it is the opposite of the {@link LabAdminApiTest#DEFAULT_HOST} value. Hence, if {@link
+   * LabAdminApiTest#DEFAULT_HOST} is set to '127.0.0.1', Unirest will return a forbidden response when
+   * making the endpoint call with the authToken (whereas it works when you manually set the host of
+   * the endpoint call to 'localhost') and vice-versa. I assume that Unirest, since it is a
+   * Singleton, makes some weird host-mapping or caching upon first request.
+   *
+   * @throws IOException
+   */
+  private void resetUnirest() throws IOException {
+
+    Unirest.shutdown();
+    Options.refresh();
+
+    HttpClient httpClient = HttpClients.custom().disableCookieManagement().build();
+    Unirest.setHttpClient(httpClient);
+  }
+}

--- a/backend/service-lib/src/main/java/org/mltooling/core/service/tests/LocalDockerLauncher.java
+++ b/backend/service-lib/src/main/java/org/mltooling/core/service/tests/LocalDockerLauncher.java
@@ -108,6 +108,10 @@ public class LocalDockerLauncher extends ExternalResource {
     return "http://" + this.serviceHost + ":" + this.servicePort;
   }
 
+  public void tagDockerImage(String dockerImage, String newTag) throws Throwable {
+    String dockerCommand = getDockerPath() +" tag " + dockerImage + " " + newTag;
+    executeCommand(dockerCommand);
+  }
   // ================ Private Methods ===================================== //
 
   private static String getDockerPath() {


### PR DESCRIPTION
<!--
Thank you for creating a pull request 🙌 ❤️
-->

**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bugfix
- [x] New Feature
- [ ] Feature Improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include a note to let us know. -->
This PR adds the possibility for a user to spawn a workspace with a different docker image than the one used by default. For this, I added an optional parameter `image` to the endpoint `/workspace/reset`. The behaviour is as follows:

* When the user doesn't specifies an image, it uses the default image.
* When the user specifies an image, this image is used to spawn the workspace. The volume under /workspace is mounted
* When the endpoint `/workspace/check` is called:
  * If the workspace has never been created, it creates one with the default image
  * If a workspace has already been created, it spawns a container with the latest image used

As a groundwork for an implementation in the front-end, I added information similar to the services in the API response (image name, container name, etc...)

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/sap/machine-learning-lab/blob/master/CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.