### PR TITLE
Added a check on file name length during upload

### DIFF
--- a/client/src/lab_client/handler/file_handler.py
+++ b/client/src/lab_client/handler/file_handler.py
@@ -5,6 +5,8 @@ from typing import Iterator, List, Optional
 
 from contaxy.clients import FileClient
 from contaxy.schema import File
+from contaxy.schema.shared import MAX_DISPLAY_NAME_LENGTH
+
 from loguru import logger
 import tqdm
 import sys
@@ -89,6 +91,10 @@ class FileHandler:
 
         if file_name is None:
             file_name = file_path.split(os.sep)[-1]
+
+        if len(file_name) > MAX_DISPLAY_NAME_LENGTH:
+            raise Exception("Error in uploading file " + file_name + ". File name is more than " + str(MAX_DISPLAY_NAME_LENGTH) + " characters.")
+            
         with open(file_path, "rb") as f:
             file = self.file_client.upload_file(
                 self.env.project, f"{data_type}s/{file_name}", f, metadata=metadata

--- a/client/tests/test_file_handler.py
+++ b/client/tests/test_file_handler.py
@@ -5,7 +5,8 @@ from lab_client import Environment
 from .conftest import test_settings
 import requests
 import pytest
-
+import random, string
+from contaxy.schema.shared import MAX_DISPLAY_NAME_LENGTH
 
 @pytest.mark.integration
 class TestFile:
@@ -151,3 +152,17 @@ class TestFile:
         for _, _, files in os.walk(local_path):
             for filename in files:
                 assert filename == tf_file_2
+    
+    @pytest.mark.xfail(raises=Exception)
+    def test_file_upload_for_characters_error(self) -> None:
+        env = Environment(lab_endpoint=test_settings.LAB_BACKEND,
+                          lab_api_token=test_settings.LAB_TOKEN,
+                          project=test_settings.LAB_PROJECT)
+        letters = string.ascii_lowercase
+        prefix_str = ''.join(random.choice(letters) for i in range(MAX_DISPLAY_NAME_LENGTH))
+        tf = tempfile.NamedTemporaryFile(prefix=prefix_str)
+        sample_text = "This is a sample text\nWith two lines"
+        with open(tf.name, 'w') as f:
+            f.write(sample_text)
+            f.seek(0)
+            env.upload_file(tf.name, "dataset")


### PR DESCRIPTION
With this commit, a check has been added to see if the file name to upload exceeds the max allowed character length(currently 128), and to raise an exception in that case.