### PR TITLE
Data types in file handler functions

### DIFF
--- a/client/src/lab_client/environment.py
+++ b/client/src/lab_client/environment.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional
+from typing import Optional, Literal
 
 from contaxy.clients import AuthClient, FileClient, ExtensionClient
 from contaxy.clients import DeploymentClient
@@ -236,7 +236,7 @@ class Environment:
     def upload_file(
         self,
         file_path: str,
-        data_type: str,
+        data_type: Literal['model', 'dataset'],
         metadata: dict = None,
         file_name: str = None,
     ) -> str:
@@ -270,7 +270,7 @@ class Environment:
     def upload_folder(
         self,
         folder_path: str,
-        data_type: str,
+        data_type: Literal['model', 'dataset'],
         metadata: dict = None,
         file_name: str = None,
     ) -> str:

--- a/client/src/lab_client/handler/file_handler.py
+++ b/client/src/lab_client/handler/file_handler.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-from typing import Iterator, List, Optional
+from typing import Iterator, List, Literal, Optional
 
 from contaxy.clients import FileClient
 from contaxy.schema import File
@@ -13,6 +13,7 @@ from lab_client.utils import file_handler_utils, request_utils
 from zipfile import ZipFile
 import shutil
 
+VALID_DATATYPES = ['dataset', 'model']
 
 class FileHandler:
     def __init__(self, env, file_client: FileClient):
@@ -65,7 +66,7 @@ class FileHandler:
     def upload_file(
         self,
         file_path: str,
-        data_type: str,
+        data_type: Literal['model', 'dataset'],
         metadata: dict = None,
         file_name: str = None,
     ) -> str:
@@ -79,6 +80,9 @@ class FileHandler:
         Returns:
             Key of the uploaded file.
         """
+        if data_type not in VALID_DATATYPES:
+            raise Exception("Invalid data type specified. Possible values are `model` or `dataset`")
+
         if os.path.isdir(file_path):
             logger.info("Path is a folder, uploading as folder instead.")
             return self.upload_folder(
@@ -98,7 +102,7 @@ class FileHandler:
     def upload_folder(
         self,
         folder_path: str,
-        data_type: str,
+        data_type: Literal['model', 'dataset'],
         metadata: dict = None,
         file_name: str = None,
     ) -> str:
@@ -112,6 +116,9 @@ class FileHandler:
         Returns:
             Key of the uploaded (zipped) folder.
         """
+        if data_type not in VALID_DATATYPES:
+            raise Exception("Invalid data type specified. Possible values are `model` or `dataset`")
+
         if os.path.isfile(folder_path):
             logger.info("Path is a file, uploading as file instead.")
             return self.upload_file(folder_path,
@@ -135,16 +142,19 @@ class FileHandler:
         return key
 
     def list_remote_files(
-        self, data_type: str = None, prefix: str = None
+        self, data_type: Literal['model', 'dataset'] = None, prefix: str = None
     ) -> List[File]:
         """List remote files from Lab instance.
 
         Args:
-            data_type (string): Data type to filter files (dataset, model...)
+            data_type (literal): Data type to filter files (dataset, model...)
             prefix (string): Key prefix to filter files. If `data_type` is provided as well, the prefix will be used to filter files from the data type.
         Returns:
             List of found `Files`
         """
+        if data_type not in VALID_DATATYPES:
+            raise Exception("Invalid data type specified. Possible values are `model` or `dataset`")
+
         path = ""
         if data_type:
             path += f"{data_type}s/"

--- a/client/tests/test_file_handler.py
+++ b/client/tests/test_file_handler.py
@@ -151,3 +151,36 @@ class TestFile:
         for _, _, files in os.walk(local_path):
             for filename in files:
                 assert filename == tf_file_2
+
+    @pytest.mark.xfail(raises=Exception)
+    def test_file_upload_with_invalid_data_type(self) -> None:
+        env = Environment(lab_endpoint=test_settings.LAB_BACKEND,
+                          lab_api_token=test_settings.LAB_TOKEN,
+                          project=test_settings.LAB_PROJECT)
+        tf = tempfile.NamedTemporaryFile()
+        sample_text = "This is a sample text\nWith two lines"
+        with open(tf.name, 'w') as f:
+            f.write(sample_text)
+            f.seek(0)
+            env.upload_file(tf.name, "datasets")
+
+    @pytest.mark.xfail(raises=Exception)
+    def test_folder_upload_with_invalid_data_type(self) -> None:
+        env = Environment(lab_endpoint=test_settings.LAB_BACKEND,
+                          lab_api_token=test_settings.LAB_TOKEN,
+                          project=test_settings.LAB_PROJECT)
+        tf_dir = tempfile.TemporaryDirectory()
+
+        env.upload_folder(tf_dir.name, "models")
+
+    @pytest.mark.xfail(raises=Exception)
+    def test_list_file_with_invalid_data_type(self) -> None:
+        env = Environment(lab_endpoint=test_settings.LAB_BACKEND,
+                          lab_api_token=test_settings.LAB_TOKEN,
+                          project=test_settings.LAB_PROJECT)
+        tf = tempfile.NamedTemporaryFile()
+        with open(tf.name, 'w') as f:
+            f.write("content")
+        env.upload_file(tf.name, "dataset")
+
+        env.file_handler.list_remote_files(data_type="datasets")


### PR DESCRIPTION
File/folder uploading using the file handler functions with invalid data type specification as an argument should throw an exception.